### PR TITLE
Add message model und Controller

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
-  before_action :set_message, only: [:show, :update, :destroy, :data]
+  before_action :set_message, only: [:show, :update, :destroy]
 
-  def send
+  def create
     @message = Message.new(message_params)
 
     if @message.save 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,8 +12,8 @@ class MessagesController < ApplicationController
   end
 
   def recieve
-    @message = Message.find_by_id_recipient(params[:id_recipient]) 
-    render json: @message, :only => [:id_sender, :cipher, :iv, :key_recipient_enc, :sig_recipient]
+    @messages = Message.where(:id_recipient => params[:id_recipient])
+    render json: @messages, :only => [:id_sender, :cipher, :iv, :key_recipient_enc, :sig_recipient]
   end
 
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,7 @@ class MessagesController < ApplicationController
   end
 
   def recieve
-    @message = Message.find(params[:id]) 
+    @message = Message.find_by_id_recipient(params[:id_recipient]) 
     render json: @message, :only => [:id_sender, :cipher, :iv, :key_recipient_enc, :sig_recipient]
   end
 
@@ -20,11 +20,11 @@ class MessagesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_message
-      @Message = Message.find(params[:id])
+      @Message = Message.find(params[:id_recipient])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def message_params
-      params.require(:message).permit(:id_recipient, :id_sender, :cipher, :iv, :key_recipient_enc, :sig_recipient)
+      params.require(:message).permit(:timestamp, :id_recipient, :id_sender, :cipher, :iv, :key_recipient_enc, :sig_recipient)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,24 +21,6 @@ class UsersController < ApplicationController
     end
   end
 
-  # # PATCH/PUT /contacts/1
-  # # PATCH/PUT /contacts/1.json
-  # def update
-  #   if @contact.update(contact_params)
-  #     head :no_content
-  #   else
-  #     render json: @contact.errors, status: :unprocessable_entity
-  #   end
-  # end
-
-  # # DELETE /contacts/1
-  # # DELETE /contacts/1.json
-  # def destroy
-  #   @contact.destroy
-
-  #   head :no_content
-  # end
-
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_user

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ActiveRecord::Base
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@
   post    "/id",          to: "users#create"
   get     "/:id",         to: "users#data"
   get     "/:id/pubkey",  to: "users#pubkey"
-  post    "/message",  to: "messages#send"
-  get     "/:id/message",  to: "messages#recieve"
+  post    "/message",     to: "messages#create"
+  get     "/:id/message", to: "messages#recieve"
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
   get     "/:id",         to: "users#data"
   get     "/:id/pubkey",  to: "users#pubkey"
   post    "/message",     to: "messages#create"
-  get     "/:id/message", to: "messages#recieve"
+  get     "/:id_recipient/message", to: "messages#recieve"
 
 
 

--- a/db/migrate/20150518140157_create_messages.rb
+++ b/db/migrate/20150518140157_create_messages.rb
@@ -1,0 +1,14 @@
+class CreateMessages < ActiveRecord::Migration
+  def change
+    create_table :messages do |t|
+      t.string :id_recipient
+      t.string :id_sender
+      t.string :cipher
+      t.string :iv
+      t.string :key_recipient_enc
+      t.string :sig_recipient
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150511133254) do
+ActiveRecord::Schema.define(version: 20150518140157) do
+
+  create_table "messages", force: :cascade do |t|
+    t.string   "id_recipient"
+    t.string   "id_sender"
+    t.string   "cipher"
+    t.string   "iv"
+    t.string   "key_recipient_enc"
+    t.string   "sig_recipient"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "salt_masterkey"

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id_recipient: MyString
+  id_sender: MyString
+  cipher: MyString
+  iv: MyString
+  key_recipient_enc: MyString
+  sig_recipient: MyString
+
+two:
+  id_recipient: MyString
+  id_sender: MyString
+  cipher: MyString
+  iv: MyString
+  key_recipient_enc: MyString
+  sig_recipient: MyString

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Message Controller funktioniert jetzt soweit, dass neue Nachrichten mit den Parametern des innren Umschlags angelegt werden können und alle Nachrichten mit einer bestimmten recipient_id abgeholt werden können.
